### PR TITLE
미완료 할일 & 완료 할일 UI

### DIFF
--- a/Boong-To-Do.xcodeproj/project.pbxproj
+++ b/Boong-To-Do.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		913874582C18909F00EC9C98 /* AddTaskView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 913874572C18909F00EC9C98 /* AddTaskView.swift */; };
 		9138745A2C18A03700EC9C98 /* DurationSelector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 913874592C18A03700EC9C98 /* DurationSelector.swift */; };
 		C330C1CF2C1C426000F951D7 /* TaskDetail.swift in Sources */ = {isa = PBXBuildFile; fileRef = C330C1CE2C1C426000F951D7 /* TaskDetail.swift */; };
+		C36DDF752C255787002D214A /* TaskViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C36DDF742C255787002D214A /* TaskViewModel.swift */; };
 		C3724ECA2C1B1F310058C67C /* .gitignore in Resources */ = {isa = PBXBuildFile; fileRef = C3724EC92C1B1F310058C67C /* .gitignore */; };
 		C3724ECC2C1B1F8D0058C67C /* .gitattributes in Resources */ = {isa = PBXBuildFile; fileRef = C3724ECB2C1B1F8D0058C67C /* .gitattributes */; };
 		C3724ECE2C1B2BE60058C67C /* TaskListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3724ECD2C1B2BE60058C67C /* TaskListView.swift */; };
@@ -58,6 +59,7 @@
 		913874572C18909F00EC9C98 /* AddTaskView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddTaskView.swift; sourceTree = "<group>"; };
 		913874592C18A03700EC9C98 /* DurationSelector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DurationSelector.swift; sourceTree = "<group>"; };
 		C330C1CE2C1C426000F951D7 /* TaskDetail.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskDetail.swift; sourceTree = "<group>"; };
+		C36DDF742C255787002D214A /* TaskViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskViewModel.swift; sourceTree = "<group>"; };
 		C3724EC92C1B1F310058C67C /* .gitignore */ = {isa = PBXFileReference; lastKnownFileType = text; path = .gitignore; sourceTree = "<group>"; };
 		C3724ECB2C1B1F8D0058C67C /* .gitattributes */ = {isa = PBXFileReference; lastKnownFileType = text; path = .gitattributes; sourceTree = "<group>"; };
 		C3724ECD2C1B2BE60058C67C /* TaskListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskListView.swift; sourceTree = "<group>"; };
@@ -115,6 +117,7 @@
 			isa = PBXGroup;
 			children = (
 				9131C8FE2C15FD5F006DE1F7 /* Boong_To_DoApp.swift */,
+				C36DDF732C25577A002D214A /* ViewModel */,
 				C334E0882C1C3AFA00492574 /* Model */,
 				C334E0862C1C3AD200492574 /* View */,
 				9131C9022C15FD61006DE1F7 /* Assets.xcassets */,
@@ -176,6 +179,14 @@
 				C3F94E962C218A6A005C7291 /* MockData.swift */,
 			);
 			path = Model;
+			sourceTree = "<group>";
+		};
+		C36DDF732C25577A002D214A /* ViewModel */ = {
+			isa = PBXGroup;
+			children = (
+				C36DDF742C255787002D214A /* TaskViewModel.swift */,
+			);
+			path = ViewModel;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -313,6 +324,7 @@
 				C3724ECE2C1B2BE60058C67C /* TaskListView.swift in Sources */,
 				913874562C1888B000EC9C98 /* EmptyListView.swift in Sources */,
 				9138745A2C18A03700EC9C98 /* DurationSelector.swift in Sources */,
+				C36DDF752C255787002D214A /* TaskViewModel.swift in Sources */,
 				913874582C18909F00EC9C98 /* AddTaskView.swift in Sources */,
 				C3F94E972C218A6A005C7291 /* MockData.swift in Sources */,
 				9131C9292C16007A006DE1F7 /* DateSelector.swift in Sources */,

--- a/Boong-To-Do/Assets.xcassets/PrimaryText.colorset/Contents.json
+++ b/Boong-To-Do/Assets.xcassets/PrimaryText.colorset/Contents.json
@@ -1,0 +1,56 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "255",
+          "green" : "255",
+          "red" : "255"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "light"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0",
+          "green" : "0",
+          "red" : "0"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "255",
+          "green" : "255",
+          "red" : "255"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Boong-To-Do/Assets.xcassets/SecondaryText.colorset/Contents.json
+++ b/Boong-To-Do/Assets.xcassets/SecondaryText.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "193",
+          "green" : "193",
+          "red" : "193"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Boong-To-Do/Boong_To_DoApp.swift
+++ b/Boong-To-Do/Boong_To_DoApp.swift
@@ -11,7 +11,7 @@ import SwiftUI
 struct Boong_To_DoApp: App {
     var body: some Scene {
         WindowGroup {
-            HomeView(dataExist: true)
+            HomeView()
         }
     }
 }

--- a/Boong-To-Do/Model/MockData.swift
+++ b/Boong-To-Do/Model/MockData.swift
@@ -8,8 +8,17 @@
 import Foundation
 
 struct MockTaskData: Identifiable {
+    // TODO: 날짜 저장 변수 필요
     let id = UUID()
-    var taskTitle: String
-    var taskDuration: Int
-    var taskHasDone: Bool
+    var taskTitle: String = "제목"
+    var taskDescription = ""
+    var taskDuration: Int = 0
+    var taskHasDone: Bool = false
+    
+    static var mockTaskArray: [MockTaskData] = [
+        MockTaskData(taskTitle: "기초디자인 포스터 1", taskDuration: 20, taskHasDone: false),
+        MockTaskData(taskTitle: "기초디자인 포스터 2", taskDuration: 40, taskHasDone: true),
+        MockTaskData(taskTitle: "할일 할일 할일 1", taskDuration: 20, taskHasDone: false),
+        MockTaskData(taskTitle: "할일 할일 할일 2", taskDuration: 30, taskHasDone: true)]
+    
 }

--- a/Boong-To-Do/View/AddTaskView.swift
+++ b/Boong-To-Do/View/AddTaskView.swift
@@ -16,14 +16,17 @@ struct AddTaskView: View {
     @Binding var addTaskModalViewIsPresented: Bool
     // 하위 뷰(시간 선택) 모달 상태
     @State var durationSelectorIsPresented = false
+    @FocusState private var isFocused: Bool
     
     var body: some View {
         VStack {
-            // TODO: 화면이 표시되자마자 키보드 활성화 되어있어야 함
-            // TODO: 키보드 활성화 상태의 모달 뷰 화면 크기 조정해야함(반만 차지하게)
             TextField("할일 제목 입력", text: $taskTitle, prompt: Text("할 일을 입력해주세요."))
                 .frame(width: 335, height: 24)
                 .padding(.top, 30)
+                .focused($isFocused)
+                .onAppear {
+                    isFocused = true
+                }
             
             TextField("설명 입력", text: $taskDesciptions, prompt: Text("설명"))
                 .frame(width: 335, height: 24)

--- a/Boong-To-Do/View/Component/TaskDetail.swift
+++ b/Boong-To-Do/View/Component/TaskDetail.swift
@@ -13,19 +13,6 @@ struct TaskDetail: View {
     var body: some View {
         VStack {
             HStack {
-                Spacer()
-                Button(action: {
-                    // TODO: 디자이너에게 물어봄
-                }, label: {
-                    Image(systemName: "ellipsis")
-                        .resizable()
-                        .scaledToFit()
-                        .frame(width: 24, height: 24)
-                        .foregroundStyle(.black)
-                })
-            }
-            
-            HStack {
                 Text("기초디자인 포스터")
                     .font(.system(size: 16))
                     .bold()

--- a/Boong-To-Do/View/Component/TaskDetail.swift
+++ b/Boong-To-Do/View/Component/TaskDetail.swift
@@ -14,7 +14,9 @@ struct TaskDetail: View {
         VStack {
             HStack {
                 Spacer()
-                Button(action: {}, label: {
+                Button(action: {
+                    // TODO: 디자이너에게 물어봄
+                }, label: {
                     Image(systemName: "ellipsis")
                         .resizable()
                         .scaledToFit()

--- a/Boong-To-Do/View/HomeView.swift
+++ b/Boong-To-Do/View/HomeView.swift
@@ -39,7 +39,7 @@ struct HomeView: View {
                 .onAppear {
                     viewModel.getTaskStates()
                 }
-            if !viewModel.notCompleteTasks.isEmpty || !viewModel.completeTasks.isEmpty {
+            if !viewModel.notCompleteTasks.isEmpty && !viewModel.completeTasks.isEmpty {
                 TaskListView(viewModel: viewModel)
             } else {
                 EmptyListView()

--- a/Boong-To-Do/View/HomeView.swift
+++ b/Boong-To-Do/View/HomeView.swift
@@ -10,6 +10,7 @@ import SwiftUI
 struct HomeView: View {
     
     @State var dataExist: Bool
+    @ObservedObject var viewModel = TaskViewModel()
     
     var body: some View {
             VStack {
@@ -37,7 +38,10 @@ struct HomeView: View {
                     .padding(.bottom, 10)
                     .scrollIndicators(.hidden)
                 if dataExist {
-                    TaskListView()
+                    TaskListView(viewModel: viewModel)
+                        .onAppear {
+                            viewModel.getTaskStates()
+                        }
                 } else {
                     EmptyListView()
                 }

--- a/Boong-To-Do/View/HomeView.swift
+++ b/Boong-To-Do/View/HomeView.swift
@@ -9,50 +9,45 @@ import SwiftUI
 
 struct HomeView: View {
     
-    @State var dataExist: Bool
     @ObservedObject var viewModel = TaskViewModel()
     
     var body: some View {
-            VStack {
-                HStack {
-                    Text("LOGO")
-                        .bold()
-                        .font(.system(size: 16))
-                        .frame(width: 48, height: 24)
-                    
-                    Spacer()
-                    
-                    Button(action: {
-                        // TODO: 버튼을 누르면 어떤 기능?
-                    }, label: {
-                        Image(systemName: "ellipsis")
-                            .resizable()
-                            .scaledToFit()
-                            .frame(width: 24, height: 24)
-                            .foregroundStyle(.black)
-                    })
-                }
-                .padding()
+        VStack {
+            HStack {
+                Text("LOGO")
+                    .bold()
+                    .font(.system(size: 16))
+                    .frame(width: 48, height: 24)
                 
-                DateSelector()
-                    .padding(.bottom, 10)
-                    .scrollIndicators(.hidden)
-                if dataExist {
-                    TaskListView(viewModel: viewModel)
-                        .onAppear {
-                            viewModel.getTaskStates()
-                        }
-                } else {
-                    EmptyListView()
-                }
+                Spacer()
+                
+                Button(action: {
+                    // TODO: 버튼을 누르면 어떤 기능?
+                }, label: {
+                    Image(systemName: "ellipsis")
+                        .resizable()
+                        .scaledToFit()
+                        .frame(width: 24, height: 24)
+                        .foregroundStyle(.black)
+                })
             }
+            .padding()
+            
+            DateSelector()
+                .padding(.bottom, 10)
+                .scrollIndicators(.hidden)
+                .onAppear {
+                    viewModel.getTaskStates()
+                }
+            if !viewModel.notCompleteTasks.isEmpty || !viewModel.completeTasks.isEmpty {
+                TaskListView(viewModel: viewModel)
+            } else {
+                EmptyListView()
+            }
+        }
     }
 }
 
-#Preview("DataExist") {
-    HomeView(dataExist: true)
-}
-
-#Preview("NoData") {
-    HomeView(dataExist: false)
+#Preview() {
+    HomeView()
 }

--- a/Boong-To-Do/View/TaskListView.swift
+++ b/Boong-To-Do/View/TaskListView.swift
@@ -12,6 +12,7 @@ struct TaskListView: View {
     
     @State var isPresented = false
     @ObservedObject var viewModel: TaskViewModel
+    @State var addTaskIsPresented = false
     
     var body: some View {
         ZStack{
@@ -66,6 +67,33 @@ struct TaskListView: View {
                     
                     
                     Spacer()
+                }
+            }
+            VStack {
+                Spacer()
+                HStack {
+                    Spacer()
+                    // 터치 시, 할일 추가 모달 나타남
+                    Button(action: {
+                        addTaskIsPresented.toggle()
+                    }, label: {
+                        ZStack {
+                            Image(systemName: "plus")
+                                .resizable()
+                                .frame(width: 23, height: 23)
+                                .foregroundStyle(.white)
+                                .frame(width: 48, height: 48)
+                                .background(.black)
+                                .clipShape(Circle())
+                        }
+                        .padding()
+                    })
+                    .sheet(isPresented: $addTaskIsPresented, content: {
+                        // 할일 추가 화면 모달뷰
+                        AddTaskView(addTaskModalViewIsPresented: $addTaskIsPresented)
+                            .presentationDetents([.height(200)])
+                            .presentationDragIndicator(.visible)
+                    })
                 }
             }
             

--- a/Boong-To-Do/View/TaskListView.swift
+++ b/Boong-To-Do/View/TaskListView.swift
@@ -22,31 +22,58 @@ struct TaskListView: View {
         ZStack{
             Color.gray.opacity(0.2)
                 .edgesIgnoringSafeArea(.all)
-            VStack {
-                HStack {
-                    Text("\(TaskArray.count)개의 할 일")
+            ScrollView {
+                VStack {
+                    // MARK: 미완료 할일 리스트
+                    Section {
+                        ForEach(TaskArray) { dummy in
+                            TaskListCell(taskTitle: dummy.taskTitle, taskDuration: dummy.taskDuration, taskHasDone: dummy.taskHasDone)
+                                .sheet(isPresented: $isPresented, content: {
+                                    TaskDetail()
+                                        .presentationDetents([.height(580)])
+                                        .presentationDragIndicator(.visible)
+                                })
+                        }
+                        .onTapGesture { isPresented.toggle() }
+                    } header: {
+                        HStack {
+                            Text("\(TaskArray.count)개의 할 일")
+                            
+                            Spacer()
+                            
+                            // TODO: 정렬 기능 구현하기
+                            Text("정렬")
+                            Image(systemName: "arrow.up.arrow.down")
+                        }
+                        .padding()
+                    }
+                    // MARK: 완료 할일 리스트
+                    Section {
+                        ForEach(TaskArray) { dummy in
+                            TaskListCell(taskTitle: dummy.taskTitle, taskDuration: dummy.taskDuration, taskHasDone: dummy.taskHasDone)
+                                .sheet(isPresented: $isPresented, content: {
+                                    TaskDetail()
+                                        .presentationDetents([.height(580)])
+                                        .presentationDragIndicator(.visible)
+                                })
+                        }
+                        .onTapGesture {
+                            isPresented.toggle()
+                        }
+                    } header: {
+                        HStack {
+                            Text("완료")
+                            
+                            Spacer()
+                        }
+                        .padding()
+                    }
+                    
                     
                     Spacer()
-                    
-                    // TODO: 정렬 기능 구현하기
-                    Text("정렬")
-                    Image(systemName: "arrow.up.arrow.down")
                 }
-                .padding()
-                
-                ForEach(TaskArray) { dummy in
-                    TaskListCell(taskTitle: dummy.taskTitle, taskDuration: dummy.taskDuration, taskHasDone: dummy.taskHasDone)
-                        .sheet(isPresented: $isPresented, content: {
-                            TaskDetail()
-                                .presentationDetents([.height(580)])
-                                .presentationDragIndicator(.visible)
-                        })
-                }
-                .onTapGesture {
-                    isPresented.toggle()
-                }
-                Spacer()
             }
+            
         }
     }
 }
@@ -62,34 +89,34 @@ struct TaskListCell: View {
     @State var taskHasDone: Bool
     
     var body: some View {
-            HStack {
-                if taskHasDone {
-                    Image(systemName: "checkmark.square")
-                }else {
-                    Image(systemName: "square")
-                }
-                
-                Text(taskTitle)
-                    .font(.system(size: 14))
-                    .padding(.horizontal, 10)
-                
-                Spacer()
-                
-                Button(action: {}, label: {
-                    Label("\(taskDuration)분", systemImage: "clock")
-                        .font(.system(size: 10))
-                        .foregroundStyle(.black)
-                })
-                .frame(width: 50, height: 18)
-                .background(.gray).opacity(0.3)
-                .clipShape(.rect(cornerRadius: 4))
-                
+        HStack {
+            if taskHasDone {
+                Image(systemName: "checkmark.square")
+            }else {
+                Image(systemName: "square")
             }
+            
+            Text(taskTitle)
+                .font(.system(size: 14))
+                .padding(.horizontal, 10)
+            
+            Spacer()
+            
+            Button(action: {}, label: {
+                Label("\(taskDuration)분", systemImage: "clock")
+                    .font(.system(size: 10))
+                    .foregroundStyle(.black)
+            })
+            .frame(width: 50, height: 18)
+            .background(.gray).opacity(0.3)
+            .clipShape(.rect(cornerRadius: 4))
+            
+        }
         .frame(width: .infinity, height: 27)
         .padding(20)
         .background(.white)
         .clipShape(.rect(cornerRadius: 12))
-        .padding(10)
+        .padding(.horizontal, 10)
     }
 }
 

--- a/Boong-To-Do/View/TaskListView.swift
+++ b/Boong-To-Do/View/TaskListView.swift
@@ -10,13 +10,8 @@ import SwiftUI
 /**할일 추가 완료 시, 할일 목록을 보여주는 화면*/
 struct TaskListView: View {
     
-    // TODO: 데이터 구조 설계하기
-    var TaskArray: [MockTaskData] = [
-        MockTaskData(taskTitle: "기초디자인 포스터 1", taskDuration: 20, taskHasDone: false),
-        MockTaskData(taskTitle: "기초디자인 포스터 2", taskDuration: 40, taskHasDone: true),
-        MockTaskData(taskTitle: "할일 할일 할일 1", taskDuration: 20, taskHasDone: false),
-        MockTaskData(taskTitle: "할일 할일 할일 2", taskDuration: 30, taskHasDone: true)]
     @State var isPresented = false
+    @ObservedObject var viewModel: TaskViewModel
     
     var body: some View {
         ZStack{
@@ -26,7 +21,7 @@ struct TaskListView: View {
                 VStack {
                     // MARK: 미완료 할일 리스트
                     Section {
-                        ForEach(TaskArray) { dummy in
+                        ForEach(viewModel.notCompleteTasks) { dummy in
                             TaskListCell(taskTitle: dummy.taskTitle, taskDuration: dummy.taskDuration, taskHasDone: dummy.taskHasDone)
                                 .sheet(isPresented: $isPresented, content: {
                                     TaskDetail()
@@ -37,7 +32,7 @@ struct TaskListView: View {
                         .onTapGesture { isPresented.toggle() }
                     } header: {
                         HStack {
-                            Text("\(TaskArray.count)개의 할 일")
+                            Text("\(viewModel.notCompleteTasks.count)개의 할 일")
                             
                             Spacer()
                             
@@ -49,7 +44,7 @@ struct TaskListView: View {
                     }
                     // MARK: 완료 할일 리스트
                     Section {
-                        ForEach(TaskArray) { dummy in
+                        ForEach(viewModel.completeTasks) { dummy in
                             TaskListCell(taskTitle: dummy.taskTitle, taskDuration: dummy.taskDuration, taskHasDone: dummy.taskHasDone)
                                 .sheet(isPresented: $isPresented, content: {
                                     TaskDetail()
@@ -79,7 +74,7 @@ struct TaskListView: View {
 }
 
 #Preview("TaskList") {
-    TaskListView()
+    TaskListView(viewModel: TaskViewModel())
 }
 
 struct TaskListCell: View {
@@ -112,7 +107,6 @@ struct TaskListCell: View {
             .clipShape(.rect(cornerRadius: 4))
             
         }
-        .frame(width: .infinity, height: 27)
         .padding(20)
         .background(.white)
         .clipShape(.rect(cornerRadius: 12))

--- a/Boong-To-Do/View/TaskListView.swift
+++ b/Boong-To-Do/View/TaskListView.swift
@@ -86,13 +86,15 @@ struct TaskListCell: View {
     var body: some View {
         HStack {
             if taskHasDone {
-                Image(systemName: "checkmark.square")
+                Image(systemName: "checkmark.square.fill")
+                    .foregroundStyle(taskHasDone ? .secondaryText.opacity(0.5) : .primaryText)
             }else {
                 Image(systemName: "square")
             }
             
             Text(taskTitle)
                 .font(.system(size: 14))
+                .foregroundStyle(taskHasDone ? .secondaryText : .primaryText)
                 .padding(.horizontal, 10)
             
             Spacer()
@@ -108,12 +110,15 @@ struct TaskListCell: View {
             
         }
         .padding(20)
-        .background(.white)
+        .background(taskHasDone ? .secondaryText.opacity(0.1) : .white)
         .clipShape(.rect(cornerRadius: 12))
         .padding(.horizontal, 10)
     }
 }
 
-#Preview("TaskCell") {
+#Preview("NotDoneTaskCell") {
     TaskListCell(taskTitle: "기초 디자인 포스터", taskDuration: 20, taskHasDone: false)
+}
+#Preview("HasDoneTaskCell") {
+    TaskListCell(taskTitle: "기초 디자인 포스터", taskDuration: 20, taskHasDone: true)
 }

--- a/Boong-To-Do/ViewModel/TaskViewModel.swift
+++ b/Boong-To-Do/ViewModel/TaskViewModel.swift
@@ -1,0 +1,23 @@
+//
+//  TaskViewModel.swift
+//  Boong-To-Do
+//
+//  Created by 황석현 on 6/21/24.
+//
+
+import Foundation
+
+class TaskViewModel: ObservableObject {
+    
+    private var model = MockTaskData()
+    @Published var completeTasks: [MockTaskData] = []
+    @Published var notCompleteTasks: [MockTaskData] = []
+    
+    func getTaskStates() {
+        for item in MockTaskData.mockTaskArray {
+            if item.taskHasDone { completeTasks.append(item)} else {
+                notCompleteTasks.append(item)
+            }
+        }
+    }
+}


### PR DESCRIPTION
브랜치 이름대로 편집 기능까지 하려다가 PR단위를 쪼개서 하려고 `PR` 작성합니다!

# TaskViewModel 추가
비비가 작업을 하시고 계실 수 있는데 화면 구성을 목적으로 임의의 `ViewModel`을 생성하였습니다.

## ViewModel
![image](https://github.com/Code-Ward/Todo-Tycoon/assets/109560875/da31355b-2a4c-4a9d-8656-9340f864c937)
`Model`의 데이터를 가지고 완료된 일, 미완료된 일을 각 배열에 넣고 
각 배열을 `Section`별로 뷰를 그립니다.
현재 구조는 빈 배열에 요소를 추가하는 형태이므로, 추후 수정이 필요합니다.

## Model
![image](https://github.com/Code-Ward/Todo-Tycoon/assets/109560875/e9a67910-9c89-4dd3-82b6-6951ba7d0653)
`MockTaskData` 구조체를 생성하고 자기 자신을 참조하는 배열을 만들었습니다.
순환 참조를 방지하기 위해 `static` 키워드를 사용하였습니다.

# 키보드 자동 활성화
제시해주신 `FocusState`를 적용해서 할일 추가 화면이 나타나면
자동으로 키보드가 활성화 됩니다!

<div>
<img width="200" src="https://github.com/Code-Ward/Todo-Tycoon/assets/109560875/00e5685f-3a49-4d47-89d3-c54a9b031612">

</div>

# 미완료/완료 구분

## 섹션 나누기 
할일 완료 상태에 따라서 섹션을 구분하였습니다.
<div>
<img width="200" src="https://github.com/Code-Ward/Todo-Tycoon/assets/109560875/a2d6e531-0da7-4144-bfa5-f0c23bf99808">
<img width="200" src="https://github.com/Code-Ward/Todo-Tycoon/assets/109560875/5e8b1439-a461-49f3-9a58-cf0fe40cb729">
</div>

데이터가 없다면 EmptyView를 표시합니다.
<img width="500" src="https://github.com/Code-Ward/Todo-Tycoon/assets/109560875/27d7e06b-5565-4125-900b-b2321ea89dbf">

## 강조 색상 추가
`primaryText`, `secondaryText` 색상을 추가하여
완료 상태에 따라서 변경됩니다.
<div>
<img width="200" src="https://github.com/Code-Ward/Todo-Tycoon/assets/109560875/50b91474-1d28-4f45-90b9-3d4ed2b9f56a">
</div>

# 할일 추가버튼 수정
`EmptyView`에만 할일 추가버튼이 있어서 
`TaskListView`에도 할일 추가버튼을 추가하였습니다.
<div>
<img width="200" src="https://github.com/Code-Ward/Todo-Tycoon/assets/109560875/806da154-bf82-4792-99a1-7cb57b55718f">
<img width="200" src="https://github.com/Code-Ward/Todo-Tycoon/assets/109560875/444401a1-0ac0-4741-9299-a32b84980f39">
</div>
