### PR TITLE
[3차]: 리스트 편집, 타이머 화면

### DIFF
--- a/Boong-To-Do.xcodeproj/project.pbxproj
+++ b/Boong-To-Do.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 		C34156452C29F555008A2454 /* TaskDetail.swift in Sources */ = {isa = PBXBuildFile; fileRef = C34156442C29F555008A2454 /* TaskDetail.swift */; };
 		C34156472C29F5B7008A2454 /* TaskProcessView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C34156462C29F5B7008A2454 /* TaskProcessView.swift */; };
 		C35262CD2C2ACABC0074C0FB /* SystemComponts.swift in Sources */ = {isa = PBXBuildFile; fileRef = C35262CC2C2ACABC0074C0FB /* SystemComponts.swift */; };
+		C35262CF2C2ACEA60074C0FB /* Enums.swift in Sources */ = {isa = PBXBuildFile; fileRef = C35262CE2C2ACEA60074C0FB /* Enums.swift */; };
 		C36DDF752C255787002D214A /* TaskViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C36DDF742C255787002D214A /* TaskViewModel.swift */; };
 		C3724ECA2C1B1F310058C67C /* .gitignore in Resources */ = {isa = PBXBuildFile; fileRef = C3724EC92C1B1F310058C67C /* .gitignore */; };
 		C3724ECC2C1B1F8D0058C67C /* .gitattributes in Resources */ = {isa = PBXBuildFile; fileRef = C3724ECB2C1B1F8D0058C67C /* .gitattributes */; };
@@ -65,6 +66,7 @@
 		C34156442C29F555008A2454 /* TaskDetail.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskDetail.swift; sourceTree = "<group>"; };
 		C34156462C29F5B7008A2454 /* TaskProcessView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskProcessView.swift; sourceTree = "<group>"; };
 		C35262CC2C2ACABC0074C0FB /* SystemComponts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemComponts.swift; sourceTree = "<group>"; };
+		C35262CE2C2ACEA60074C0FB /* Enums.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Enums.swift; sourceTree = "<group>"; };
 		C36DDF742C255787002D214A /* TaskViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskViewModel.swift; sourceTree = "<group>"; };
 		C3724EC92C1B1F310058C67C /* .gitignore */ = {isa = PBXFileReference; lastKnownFileType = text; path = .gitignore; sourceTree = "<group>"; };
 		C3724ECB2C1B1F8D0058C67C /* .gitattributes */ = {isa = PBXFileReference; lastKnownFileType = text; path = .gitattributes; sourceTree = "<group>"; };
@@ -186,6 +188,7 @@
 			isa = PBXGroup;
 			children = (
 				C3F94E962C218A6A005C7291 /* MockData.swift */,
+				C35262CE2C2ACEA60074C0FB /* Enums.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -334,6 +337,7 @@
 				C34156472C29F5B7008A2454 /* TaskProcessView.swift in Sources */,
 				913874562C1888B000EC9C98 /* EmptyListView.swift in Sources */,
 				9138745A2C18A03700EC9C98 /* DurationSelector.swift in Sources */,
+				C35262CF2C2ACEA60074C0FB /* Enums.swift in Sources */,
 				C36DDF752C255787002D214A /* TaskViewModel.swift in Sources */,
 				913874582C18909F00EC9C98 /* AddTaskView.swift in Sources */,
 				C34156452C29F555008A2454 /* TaskDetail.swift in Sources */,

--- a/Boong-To-Do.xcodeproj/project.pbxproj
+++ b/Boong-To-Do.xcodeproj/project.pbxproj
@@ -23,6 +23,7 @@
 		C34156472C29F5B7008A2454 /* TaskProcessView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C34156462C29F5B7008A2454 /* TaskProcessView.swift */; };
 		C35262CD2C2ACABC0074C0FB /* SystemComponts.swift in Sources */ = {isa = PBXBuildFile; fileRef = C35262CC2C2ACABC0074C0FB /* SystemComponts.swift */; };
 		C35262CF2C2ACEA60074C0FB /* Enums.swift in Sources */ = {isa = PBXBuildFile; fileRef = C35262CE2C2ACEA60074C0FB /* Enums.swift */; };
+		C35262D12C2AD80F0074C0FB /* CompletionMemo.swift in Sources */ = {isa = PBXBuildFile; fileRef = C35262D02C2AD80F0074C0FB /* CompletionMemo.swift */; };
 		C36DDF752C255787002D214A /* TaskViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C36DDF742C255787002D214A /* TaskViewModel.swift */; };
 		C3724ECA2C1B1F310058C67C /* .gitignore in Resources */ = {isa = PBXBuildFile; fileRef = C3724EC92C1B1F310058C67C /* .gitignore */; };
 		C3724ECC2C1B1F8D0058C67C /* .gitattributes in Resources */ = {isa = PBXBuildFile; fileRef = C3724ECB2C1B1F8D0058C67C /* .gitattributes */; };
@@ -67,6 +68,7 @@
 		C34156462C29F5B7008A2454 /* TaskProcessView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskProcessView.swift; sourceTree = "<group>"; };
 		C35262CC2C2ACABC0074C0FB /* SystemComponts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemComponts.swift; sourceTree = "<group>"; };
 		C35262CE2C2ACEA60074C0FB /* Enums.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Enums.swift; sourceTree = "<group>"; };
+		C35262D02C2AD80F0074C0FB /* CompletionMemo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompletionMemo.swift; sourceTree = "<group>"; };
 		C36DDF742C255787002D214A /* TaskViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskViewModel.swift; sourceTree = "<group>"; };
 		C3724EC92C1B1F310058C67C /* .gitignore */ = {isa = PBXFileReference; lastKnownFileType = text; path = .gitignore; sourceTree = "<group>"; };
 		C3724ECB2C1B1F8D0058C67C /* .gitattributes */ = {isa = PBXFileReference; lastKnownFileType = text; path = .gitattributes; sourceTree = "<group>"; };
@@ -175,6 +177,7 @@
 		C334E0872C1C3ADB00492574 /* Component */ = {
 			isa = PBXGroup;
 			children = (
+				C35262D02C2AD80F0074C0FB /* CompletionMemo.swift */,
 				913874592C18A03700EC9C98 /* DurationSelector.swift */,
 				9131C9282C16007A006DE1F7 /* DateSelector.swift */,
 				C330C1CE2C1C426000F951D7 /* TaskTimer.swift */,
@@ -346,6 +349,7 @@
 				9131C9012C15FD5F006DE1F7 /* HomeView.swift in Sources */,
 				C330C1CF2C1C426000F951D7 /* TaskTimer.swift in Sources */,
 				9131C8FF2C15FD5F006DE1F7 /* Boong_To_DoApp.swift in Sources */,
+				C35262D12C2AD80F0074C0FB /* CompletionMemo.swift in Sources */,
 				C35262CD2C2ACABC0074C0FB /* SystemComponts.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Boong-To-Do.xcodeproj/project.pbxproj
+++ b/Boong-To-Do.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 		C330C1CF2C1C426000F951D7 /* TaskTimer.swift in Sources */ = {isa = PBXBuildFile; fileRef = C330C1CE2C1C426000F951D7 /* TaskTimer.swift */; };
 		C34156452C29F555008A2454 /* TaskDetail.swift in Sources */ = {isa = PBXBuildFile; fileRef = C34156442C29F555008A2454 /* TaskDetail.swift */; };
 		C34156472C29F5B7008A2454 /* TaskProcessView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C34156462C29F5B7008A2454 /* TaskProcessView.swift */; };
+		C35262CD2C2ACABC0074C0FB /* SystemComponts.swift in Sources */ = {isa = PBXBuildFile; fileRef = C35262CC2C2ACABC0074C0FB /* SystemComponts.swift */; };
 		C36DDF752C255787002D214A /* TaskViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C36DDF742C255787002D214A /* TaskViewModel.swift */; };
 		C3724ECA2C1B1F310058C67C /* .gitignore in Resources */ = {isa = PBXBuildFile; fileRef = C3724EC92C1B1F310058C67C /* .gitignore */; };
 		C3724ECC2C1B1F8D0058C67C /* .gitattributes in Resources */ = {isa = PBXBuildFile; fileRef = C3724ECB2C1B1F8D0058C67C /* .gitattributes */; };
@@ -63,6 +64,7 @@
 		C330C1CE2C1C426000F951D7 /* TaskTimer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskTimer.swift; sourceTree = "<group>"; };
 		C34156442C29F555008A2454 /* TaskDetail.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskDetail.swift; sourceTree = "<group>"; };
 		C34156462C29F5B7008A2454 /* TaskProcessView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskProcessView.swift; sourceTree = "<group>"; };
+		C35262CC2C2ACABC0074C0FB /* SystemComponts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemComponts.swift; sourceTree = "<group>"; };
 		C36DDF742C255787002D214A /* TaskViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskViewModel.swift; sourceTree = "<group>"; };
 		C3724EC92C1B1F310058C67C /* .gitignore */ = {isa = PBXFileReference; lastKnownFileType = text; path = .gitignore; sourceTree = "<group>"; };
 		C3724ECB2C1B1F8D0058C67C /* .gitattributes */ = {isa = PBXFileReference; lastKnownFileType = text; path = .gitattributes; sourceTree = "<group>"; };
@@ -175,6 +177,7 @@
 				9131C9282C16007A006DE1F7 /* DateSelector.swift */,
 				C330C1CE2C1C426000F951D7 /* TaskTimer.swift */,
 				C34156442C29F555008A2454 /* TaskDetail.swift */,
+				C35262CC2C2ACABC0074C0FB /* SystemComponts.swift */,
 			);
 			path = Component;
 			sourceTree = "<group>";
@@ -339,6 +342,7 @@
 				9131C9012C15FD5F006DE1F7 /* HomeView.swift in Sources */,
 				C330C1CF2C1C426000F951D7 /* TaskTimer.swift in Sources */,
 				9131C8FF2C15FD5F006DE1F7 /* Boong_To_DoApp.swift in Sources */,
+				C35262CD2C2ACABC0074C0FB /* SystemComponts.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Boong-To-Do.xcodeproj/project.pbxproj
+++ b/Boong-To-Do.xcodeproj/project.pbxproj
@@ -18,7 +18,9 @@
 		913874562C1888B000EC9C98 /* EmptyListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 913874552C1888B000EC9C98 /* EmptyListView.swift */; };
 		913874582C18909F00EC9C98 /* AddTaskView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 913874572C18909F00EC9C98 /* AddTaskView.swift */; };
 		9138745A2C18A03700EC9C98 /* DurationSelector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 913874592C18A03700EC9C98 /* DurationSelector.swift */; };
-		C330C1CF2C1C426000F951D7 /* TaskDetail.swift in Sources */ = {isa = PBXBuildFile; fileRef = C330C1CE2C1C426000F951D7 /* TaskDetail.swift */; };
+		C330C1CF2C1C426000F951D7 /* TaskTimer.swift in Sources */ = {isa = PBXBuildFile; fileRef = C330C1CE2C1C426000F951D7 /* TaskTimer.swift */; };
+		C34156452C29F555008A2454 /* TaskDetail.swift in Sources */ = {isa = PBXBuildFile; fileRef = C34156442C29F555008A2454 /* TaskDetail.swift */; };
+		C34156472C29F5B7008A2454 /* TaskProcessView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C34156462C29F5B7008A2454 /* TaskProcessView.swift */; };
 		C36DDF752C255787002D214A /* TaskViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C36DDF742C255787002D214A /* TaskViewModel.swift */; };
 		C3724ECA2C1B1F310058C67C /* .gitignore in Resources */ = {isa = PBXBuildFile; fileRef = C3724EC92C1B1F310058C67C /* .gitignore */; };
 		C3724ECC2C1B1F8D0058C67C /* .gitattributes in Resources */ = {isa = PBXBuildFile; fileRef = C3724ECB2C1B1F8D0058C67C /* .gitattributes */; };
@@ -58,7 +60,9 @@
 		913874552C1888B000EC9C98 /* EmptyListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyListView.swift; sourceTree = "<group>"; };
 		913874572C18909F00EC9C98 /* AddTaskView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddTaskView.swift; sourceTree = "<group>"; };
 		913874592C18A03700EC9C98 /* DurationSelector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DurationSelector.swift; sourceTree = "<group>"; };
-		C330C1CE2C1C426000F951D7 /* TaskDetail.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskDetail.swift; sourceTree = "<group>"; };
+		C330C1CE2C1C426000F951D7 /* TaskTimer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskTimer.swift; sourceTree = "<group>"; };
+		C34156442C29F555008A2454 /* TaskDetail.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskDetail.swift; sourceTree = "<group>"; };
+		C34156462C29F5B7008A2454 /* TaskProcessView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskProcessView.swift; sourceTree = "<group>"; };
 		C36DDF742C255787002D214A /* TaskViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskViewModel.swift; sourceTree = "<group>"; };
 		C3724EC92C1B1F310058C67C /* .gitignore */ = {isa = PBXFileReference; lastKnownFileType = text; path = .gitignore; sourceTree = "<group>"; };
 		C3724ECB2C1B1F8D0058C67C /* .gitattributes */ = {isa = PBXFileReference; lastKnownFileType = text; path = .gitattributes; sourceTree = "<group>"; };
@@ -158,6 +162,7 @@
 				913874552C1888B000EC9C98 /* EmptyListView.swift */,
 				9131C9002C15FD5F006DE1F7 /* HomeView.swift */,
 				C3724ECD2C1B2BE60058C67C /* TaskListView.swift */,
+				C34156462C29F5B7008A2454 /* TaskProcessView.swift */,
 				C334E0872C1C3ADB00492574 /* Component */,
 			);
 			path = View;
@@ -168,7 +173,8 @@
 			children = (
 				913874592C18A03700EC9C98 /* DurationSelector.swift */,
 				9131C9282C16007A006DE1F7 /* DateSelector.swift */,
-				C330C1CE2C1C426000F951D7 /* TaskDetail.swift */,
+				C330C1CE2C1C426000F951D7 /* TaskTimer.swift */,
+				C34156442C29F555008A2454 /* TaskDetail.swift */,
 			);
 			path = Component;
 			sourceTree = "<group>";
@@ -322,14 +328,16 @@
 			buildActionMask = 2147483647;
 			files = (
 				C3724ECE2C1B2BE60058C67C /* TaskListView.swift in Sources */,
+				C34156472C29F5B7008A2454 /* TaskProcessView.swift in Sources */,
 				913874562C1888B000EC9C98 /* EmptyListView.swift in Sources */,
 				9138745A2C18A03700EC9C98 /* DurationSelector.swift in Sources */,
 				C36DDF752C255787002D214A /* TaskViewModel.swift in Sources */,
 				913874582C18909F00EC9C98 /* AddTaskView.swift in Sources */,
+				C34156452C29F555008A2454 /* TaskDetail.swift in Sources */,
 				C3F94E972C218A6A005C7291 /* MockData.swift in Sources */,
 				9131C9292C16007A006DE1F7 /* DateSelector.swift in Sources */,
 				9131C9012C15FD5F006DE1F7 /* HomeView.swift in Sources */,
-				C330C1CF2C1C426000F951D7 /* TaskDetail.swift in Sources */,
+				C330C1CF2C1C426000F951D7 /* TaskTimer.swift in Sources */,
 				9131C8FF2C15FD5F006DE1F7 /* Boong_To_DoApp.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Boong-To-Do/Assets.xcassets/TextBoxColor.colorset/Contents.json
+++ b/Boong-To-Do/Assets.xcassets/TextBoxColor.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "245",
+          "green" : "245",
+          "red" : "245"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "255",
+          "green" : "255",
+          "red" : "255"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Boong-To-Do/Model/Enums.swift
+++ b/Boong-To-Do/Model/Enums.swift
@@ -1,0 +1,50 @@
+//
+//  Enums.swift
+//  Boong-To-Do
+//
+//  Created by 황석현 on 6/25/24.
+//
+
+import Foundation
+
+/**시스템 이미지 열거형
+ 
+ */
+enum SystemImage {
+    case plus
+    case play
+    case pause
+    case ellipsis
+    case clock
+    case alignArrow
+    case leftArrow
+    case rightArrow
+    case xMark
+    case trash
+    
+    var name: String {
+        switch self {
+        case .plus:
+            "plus"
+        case .play:
+            "play.fill"
+        case .pause:
+            "pause.fill"
+        case .ellipsis:
+            "ellipsis"
+        case .clock:
+            "clock"
+        case .alignArrow:
+            "arrow.up.arrow.down"
+        case .leftArrow:
+            "arrowtriangle.left.fill"
+        case .rightArrow:
+            "arrowtriangle.right.fill"
+        case .xMark:
+            "xmark"
+        case .trash:
+            "trash"
+        }
+    }
+}
+

--- a/Boong-To-Do/Model/MockData.swift
+++ b/Boong-To-Do/Model/MockData.swift
@@ -19,6 +19,6 @@ struct MockTaskData: Identifiable {
         MockTaskData(taskTitle: "기초디자인 포스터 1", taskDuration: 20, taskHasDone: false),
         MockTaskData(taskTitle: "기초디자인 포스터 2", taskDuration: 40, taskHasDone: true),
         MockTaskData(taskTitle: "할일 할일 할일 1", taskDuration: 20, taskHasDone: false),
-        MockTaskData(taskTitle: "할일 할일 할일 2", taskDuration: 30, taskHasDone: true)]
-    
+        MockTaskData(taskTitle: "할일 할일 할일 2", taskDuration: 30, taskHasDone: true)
+    ]
 }

--- a/Boong-To-Do/View/AddTaskView.swift
+++ b/Boong-To-Do/View/AddTaskView.swift
@@ -40,7 +40,7 @@ struct AddTaskView: View {
                     HStack {
                         Label(
                             title: { Text("예상 소요 시간") },
-                            icon: { Image(systemName: "clock") }
+                            icon: { Image(systemName: SystemImage.clock.name) }
                         )
                         .foregroundStyle(.gray)
                         .frame(width: 140, height: 40)

--- a/Boong-To-Do/View/Component/CompletionMemo.swift
+++ b/Boong-To-Do/View/Component/CompletionMemo.swift
@@ -1,0 +1,19 @@
+//
+//  CompletionMemo.swift
+//  Boong-To-Do
+//
+//  Created by 황석현 on 6/25/24.
+//
+
+import SwiftUI
+
+/**할일 완료시 메모를 작성하는 화면*/
+struct CompletionMemo: View {
+    var body: some View {
+        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+    }
+}
+
+#Preview {
+    CompletionMemo()
+}

--- a/Boong-To-Do/View/Component/CompletionMemo.swift
+++ b/Boong-To-Do/View/Component/CompletionMemo.swift
@@ -9,8 +9,26 @@ import SwiftUI
 
 /**할일 완료시 메모를 작성하는 화면*/
 struct CompletionMemo: View {
+    
+    @State var inputMemo = ""
+    
     var body: some View {
-        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+        VStack(alignment: .leading) {
+            
+            TaskDetail()
+            
+            Text("메모")
+                .foregroundStyle(.secondary)
+            
+            TextField(text: $inputMemo) {
+                Text("완료한 메모 작성해주세요")
+            }
+            .padding()
+            .frame(maxWidth: .infinity, maxHeight: 216, alignment: .top)
+            .background(.textBox)
+            .clipShape(.rect(cornerRadius: 12))
+        }
+        .padding()
     }
 }
 

--- a/Boong-To-Do/View/Component/DateSelector.swift
+++ b/Boong-To-Do/View/Component/DateSelector.swift
@@ -25,7 +25,7 @@ struct DateSelector: View {
                 Button(action: {
                     // TODO: 터치 시, 월 변경하기
                 }, label: {
-                    Image(systemName: "arrowtriangle.left.fill")
+                    Image(systemName: SystemImage.leftArrow.name)
                         .frame(width: 20, height: 20)
                         .foregroundStyle(.gray)
                         .padding(.leading)
@@ -39,7 +39,7 @@ struct DateSelector: View {
                 Button(action: {
                     // TODO: 터치 시, 월 변경하기
                 }, label: {
-                    Image(systemName: "arrowtriangle.right.fill")
+                    Image(systemName: SystemImage.rightArrow.name)
                         .frame(width: 20, height: 20)
                         .foregroundStyle(.gray)
                 })

--- a/Boong-To-Do/View/Component/DurationSelector.swift
+++ b/Boong-To-Do/View/Component/DurationSelector.swift
@@ -26,7 +26,7 @@ struct DurationSelector: View {
                 HStack {
                     Spacer()
                     
-                    Image(systemName: "xmark")
+                    Image(systemName: SystemImage.xMark.name)
                         .padding(.horizontal)
                         .foregroundStyle(.black)
                         .bold()

--- a/Boong-To-Do/View/Component/SystemComponts.swift
+++ b/Boong-To-Do/View/Component/SystemComponts.swift
@@ -1,0 +1,57 @@
+//
+//  SystemComponts.swift
+//  Boong-To-Do
+//
+//  Created by 황석현 on 6/25/24.
+//
+
+import SwiftUI
+
+/**기본적으로 사용되는 뷰 컴포넌트들*/
+struct SystemComponts: View {
+    var body: some View {
+        VStack {
+            Text("dd")
+            TextButton()
+            SystemImageButton()
+        }
+    }
+}
+
+/**글자가 포함된 텍스트박스*/
+struct TextButton: View {
+    
+    var content: String = "Text"
+    
+    var body: some View {
+        // TODO: 타이머 시작하기
+        Text("\(content)")
+            .foregroundStyle(.white)
+            .bold()
+            .frame(width: 140)
+            .padding()
+            .background(.black)
+            .clipShape(.rect(cornerRadius: 100))
+    }
+}
+
+struct SystemImageButton: View {
+    
+    var systemImageName: String = "plus"
+    var width: CGFloat = 24.0
+    var height: CGFloat = 24.0
+    
+    var body: some View {
+        Image(systemName: systemImageName)
+            .resizable()
+            .frame(width: width, height: height)
+            .foregroundStyle(.white)
+            .frame(width: width * 2, height: height * 2)
+            .background(.black)
+            .clipShape(Circle())
+    }
+}
+
+#Preview {
+    SystemComponts()
+}

--- a/Boong-To-Do/View/Component/SystemComponts.swift
+++ b/Boong-To-Do/View/Component/SystemComponts.swift
@@ -11,9 +11,8 @@ import SwiftUI
 struct SystemComponts: View {
     var body: some View {
         VStack {
-            Text("dd")
             TextButton()
-            SystemImageButton()
+            SystemImageButton(imageName: SystemImage.plus.name)
         }
     }
 }
@@ -28,7 +27,7 @@ struct TextButton: View {
         Text("\(content)")
             .foregroundStyle(.white)
             .bold()
-            .frame(width: 140)
+            .frame(minWidth: 120)
             .padding()
             .background(.black)
             .clipShape(.rect(cornerRadius: 100))
@@ -37,16 +36,22 @@ struct TextButton: View {
 
 struct SystemImageButton: View {
     
-    var systemImageName: String = "plus"
-    var width: CGFloat = 24.0
-    var height: CGFloat = 24.0
+    var imageName: String
+    var width: CGFloat
+    var height: CGFloat
+    
+    init(imageName: String, width: CGFloat = 24.0, height: CGFloat = 24.0) {
+            self.imageName = imageName
+            self.width = width
+            self.height = height
+        }
     
     var body: some View {
-        Image(systemName: systemImageName)
+        Image(systemName: imageName)
             .resizable()
             .frame(width: width, height: height)
             .foregroundStyle(.white)
-            .frame(width: width * 2, height: height * 2)
+            .frame(width: 48, height: 48)
             .background(.black)
             .clipShape(Circle())
     }

--- a/Boong-To-Do/View/Component/TaskDetail.swift
+++ b/Boong-To-Do/View/Component/TaskDetail.swift
@@ -17,19 +17,36 @@ struct TaskDetail: View {
     var body: some View {
         VStack {
             HStack {
+                Spacer()
+                Menu {
+                    Button(role: .destructive, action: {
+                        print("삭제하기 성공")
+                    }, label: {
+                        Label("삭제하기", systemImage: "trash")
+                    })
+                } label: {
+                    Image(systemName: "ellipsis")
+                        .resizable()
+                        .scaledToFit()
+                        .frame(width: 24, height: 24)
+                        .foregroundStyle(.black)
+                }
+            }
+            .padding(.top, 20)
+
+            HStack {
                 Text("\(title)")
                     .font(.system(size: 16))
                     .bold()
-                    .padding(.bottom, 10)
+                    .frame(width: .infinity, height: 24)
                 Spacer()
             }
             
             HStack {
                 Text("\(description)")
                     .font(.system(size: 12))
-                    .frame(maxHeight: 145, alignment: .top)
-                    .padding(.bottom, 15)
-                    .layoutPriority(1)
+                    .frame(minHeight: 50, alignment: .top)
+                    .lineLimit(8)
                 
                 Spacer()
             }
@@ -39,19 +56,21 @@ struct TaskDetail: View {
                     // TODO: 예상소요시간 데이터 연동 필요
                     title: { 
                         Text("예상 소요 시간 \(time)분")
+                            .font(.system(size: 12))
                     },
                     icon: { 
                         Image(systemName: "clock")
+                            .frame(width: 18, height: 18)
                     }
                 )
                 .foregroundStyle(.gray)
-                .padding()
-                .frame(height: 40)
+                .frame(width: 140, height: 30)
                 .background(.gray.opacity(0.1))
                 .clipShape(.rect(cornerRadius: 4))
                 
                 Spacer()
             }
+            Spacer()
         }
     }
 }

--- a/Boong-To-Do/View/Component/TaskDetail.swift
+++ b/Boong-To-Do/View/Component/TaskDetail.swift
@@ -1,19 +1,23 @@
 //
-//  TaskTimer.swift
+//  TaskDetail.swift
 //  Boong-To-Do
 //
-//  Created by 황석현 on 6/14/24.
+//  Created by 황석현 on 6/25/24.
 //
 
 import SwiftUI
 
-/**할일 시작 시, 보여지는 타이머 모달 화면*/
+/**할일 상세사항을 보여주는 뷰*/
 struct TaskDetail: View {
+    
+    var title: String = "기초디자인 포스터"
+    var description: String = "설명 설명 설명 설명 설명 설명 설명 설명"
+    var time: Int = 20
     
     var body: some View {
         VStack {
             HStack {
-                Text("기초디자인 포스터")
+                Text("\(title)")
                     .font(.system(size: 16))
                     .bold()
                     .padding(.bottom, 10)
@@ -21,17 +25,24 @@ struct TaskDetail: View {
             }
             
             HStack {
-                Text("설명 설명 설명 설명 설명 설명 설명 설명 ")
+                Text("\(description)")
                     .font(.system(size: 12))
+                    .frame(maxHeight: 145, alignment: .top)
                     .padding(.bottom, 15)
+                    .layoutPriority(1)
+                
                 Spacer()
             }
             
             HStack {
                 Label(
                     // TODO: 예상소요시간 데이터 연동 필요
-                    title: { Text("예상 소요 시간 20분") },
-                    icon: { Image(systemName: "clock") }
+                    title: { 
+                        Text("예상 소요 시간 \(time)분")
+                    },
+                    icon: { 
+                        Image(systemName: "clock")
+                    }
                 )
                 .foregroundStyle(.gray)
                 .padding()
@@ -41,69 +52,9 @@ struct TaskDetail: View {
                 
                 Spacer()
             }
-            .padding(.bottom, 40)
-            
-            TaskTimer()
-            
-        }
-        .padding(.horizontal, 20)
-    }
-}
-
-struct TaskTimer: View {
-    
-    // TODO: 데이터 연동하기
-    @State var progress = 0.6
-    
-    var body: some View {
-        VStack {
-            ZStack {
-                Circle()
-                    .stroke(lineWidth: 15)
-                    .opacity(0.3)
-                    .frame(width: 250, height: 250)
-                    .foregroundColor(.gray)
-                
-                VStack {
-                    // TODO: 데이터 연동하기
-                    Text("20:00")
-                        .font(.system(size: 70))
-                        .foregroundStyle(.opacity(0.5))
-                    // TODO: 데이터 연동하기
-                    Text("20분")
-                        .font(.system(size: 16))
-                        .foregroundStyle(.opacity(0.5))
-                }
-                .padding(40)
-                
-                Circle()
-                    .trim(from: 0.0, to: CGFloat(min(progress, 1.0)))
-                    .stroke(style: StrokeStyle(lineWidth: 15, lineCap: .round, lineJoin: .round))
-                    .frame(width: 250, height: 250)
-                    .foregroundColor(Color(.black))
-                    .rotationEffect(Angle(degrees: 270.0))
-            }
-            
-            Button(action: {
-                // TODO: 타이머 시작하기
-            }, label: {
-                Text("타이머 시작하기")
-                    .foregroundStyle(.white)
-                    .bold()
-                    .frame(width: 140)
-                    .padding()
-                    .background(.black)
-                    .clipShape(.rect(cornerRadius: 100))
-            })
-            .padding(.top, 20)
         }
     }
 }
-
 #Preview("TaskDetail") {
     TaskDetail()
-}
-
-#Preview("TaskTimer") {
-    TaskTimer()
 }

--- a/Boong-To-Do/View/Component/TaskDetail.swift
+++ b/Boong-To-Do/View/Component/TaskDetail.swift
@@ -13,6 +13,7 @@ struct TaskDetail: View {
     var title: String = "기초디자인 포스터"
     var description: String = "설명 설명 설명 설명 설명 설명 설명 설명"
     var time: Int = 20
+    @State var isPresented = false
     
     var body: some View {
         VStack {
@@ -20,6 +21,7 @@ struct TaskDetail: View {
                 Spacer()
                 Menu {
                     Button(role: .destructive, action: {
+                        isPresented.toggle()
                         print("삭제하기 성공")
                     }, label: {
                         Label("삭제하기", systemImage: "trash")
@@ -31,6 +33,16 @@ struct TaskDetail: View {
                         .frame(width: 24, height: 24)
                         .foregroundStyle(.black)
                 }
+                .alert(isPresented: $isPresented) {
+                    let deleteButton = Alert.Button.default(Text("취소")) {
+                        isPresented.toggle()
+                    }
+                    let cancelButton = Alert.Button.cancel(Text("삭제하기")) {
+                        // TODO: 데이터 삭제기능 추가
+                        print("데이터 삭제")
+                    }
+                    return Alert(title: Text("할 일 삭제"), message: Text("할일을 정말 삭제하시겠습니까?"), primaryButton: cancelButton, secondaryButton: deleteButton)
+                }
             }
             .padding(.top, 20)
 
@@ -38,9 +50,10 @@ struct TaskDetail: View {
                 Text("\(title)")
                     .font(.system(size: 16))
                     .bold()
-                    .frame(width: .infinity, height: 24)
                 Spacer()
             }
+            .frame(maxWidth: .infinity)
+            .frame(height: 24)
             
             HStack {
                 Text("\(description)")

--- a/Boong-To-Do/View/Component/TaskDetail.swift
+++ b/Boong-To-Do/View/Component/TaskDetail.swift
@@ -24,10 +24,10 @@ struct TaskDetail: View {
                         isPresented.toggle()
                         print("삭제하기 성공")
                     }, label: {
-                        Label("삭제하기", systemImage: "trash")
+                        Label("삭제하기", systemImage: SystemImage.trash.name)
                     })
                 } label: {
-                    Image(systemName: "ellipsis")
+                    Image(systemName: SystemImage.ellipsis.name)
                         .resizable()
                         .scaledToFit()
                         .frame(width: 24, height: 24)
@@ -72,7 +72,7 @@ struct TaskDetail: View {
                             .font(.system(size: 12))
                     },
                     icon: { 
-                        Image(systemName: "clock")
+                        Image(systemName: SystemImage.clock.name)
                             .frame(width: 18, height: 18)
                     }
                 )

--- a/Boong-To-Do/View/Component/TaskDetail.swift
+++ b/Boong-To-Do/View/Component/TaskDetail.swift
@@ -61,13 +61,12 @@ struct TaskDetail: View {
 
 struct EllipsisMenu: View {
     
-    @Binding var isPresented: Bool
+    @State var isPresented = false
     
     var body: some View {
         Menu {
             Button(role: .destructive, action: {
                 isPresented.toggle()
-                print("삭제하기 성공")
             }, label: {
                 Label("삭제하기", systemImage: SystemImage.trash.name)
             })

--- a/Boong-To-Do/View/Component/TaskDetail.swift
+++ b/Boong-To-Do/View/Component/TaskDetail.swift
@@ -17,34 +17,6 @@ struct TaskDetail: View {
     
     var body: some View {
         VStack {
-            HStack {
-                Spacer()
-                Menu {
-                    Button(role: .destructive, action: {
-                        isPresented.toggle()
-                        print("삭제하기 성공")
-                    }, label: {
-                        Label("삭제하기", systemImage: SystemImage.trash.name)
-                    })
-                } label: {
-                    Image(systemName: SystemImage.ellipsis.name)
-                        .resizable()
-                        .scaledToFit()
-                        .frame(width: 24, height: 24)
-                        .foregroundStyle(.black)
-                }
-                .alert(isPresented: $isPresented) {
-                    let deleteButton = Alert.Button.default(Text("취소")) {
-                        isPresented.toggle()
-                    }
-                    let cancelButton = Alert.Button.cancel(Text("삭제하기")) {
-                        // TODO: 데이터 삭제기능 추가
-                        print("데이터 삭제")
-                    }
-                    return Alert(title: Text("할 일 삭제"), message: Text("할일을 정말 삭제하시겠습니까?"), primaryButton: cancelButton, secondaryButton: deleteButton)
-                }
-            }
-            .padding(.top, 20)
 
             HStack {
                 Text("\(title)")
@@ -83,10 +55,42 @@ struct TaskDetail: View {
                 
                 Spacer()
             }
-            Spacer()
         }
     }
 }
+
+struct EllipsisMenu: View {
+    
+    @Binding var isPresented: Bool
+    
+    var body: some View {
+        Menu {
+            Button(role: .destructive, action: {
+                isPresented.toggle()
+                print("삭제하기 성공")
+            }, label: {
+                Label("삭제하기", systemImage: SystemImage.trash.name)
+            })
+        } label: {
+            Image(systemName: SystemImage.ellipsis.name)
+                .resizable()
+                .scaledToFit()
+                .frame(width: 24, height: 24)
+                .foregroundStyle(.black)
+        }
+        .alert(isPresented: $isPresented) {
+            let deleteButton = Alert.Button.default(Text("취소")) {
+                isPresented.toggle()
+            }
+            let cancelButton = Alert.Button.cancel(Text("삭제하기")) {
+                // TODO: 데이터 삭제기능 추가
+                print("데이터 삭제")
+            }
+            return Alert(title: Text("할 일 삭제"), message: Text("할일을 정말 삭제하시겠습니까?"), primaryButton: cancelButton, secondaryButton: deleteButton)
+        }
+    }
+}
+
 #Preview("TaskDetail") {
     TaskDetail()
 }

--- a/Boong-To-Do/View/Component/TaskTimer.swift
+++ b/Boong-To-Do/View/Component/TaskTimer.swift
@@ -53,7 +53,7 @@ struct TaskTimer: View {
                     .background(.black)
                     .clipShape(.rect(cornerRadius: 100))
             })
-            .padding(.top, 20)
+            .padding(.vertical, 20)
         }
     }
 }

--- a/Boong-To-Do/View/Component/TaskTimer.swift
+++ b/Boong-To-Do/View/Component/TaskTimer.swift
@@ -69,8 +69,11 @@ struct TaskTimer: View {
                             SystemImageButton(imageName: SystemImage.pause.name, width: 12, height: 12)
                         })
                     }
-                    
-                    TextButton(content: "할 일 완료")
+                    Button {
+                        
+                    } label: {
+                        TextButton(content: "할 일 완료")
+                    }
                 }
                 .padding(.vertical, 20)
             }

--- a/Boong-To-Do/View/Component/TaskTimer.swift
+++ b/Boong-To-Do/View/Component/TaskTimer.swift
@@ -41,22 +41,17 @@ struct TaskTimer: View {
                     .foregroundColor(Color(.black))
                     .rotationEffect(Angle(degrees: 270.0))
             }
-            
+            // TODO: 타이머 시작하면, 버튼 2개 생성(재생/정지, 할일 완료)
             Button(action: {
                 // TODO: 타이머 시작하기
             }, label: {
-                Text("타이머 시작하기")
-                    .foregroundStyle(.white)
-                    .bold()
-                    .frame(width: 140)
-                    .padding()
-                    .background(.black)
-                    .clipShape(.rect(cornerRadius: 100))
+                TextButton(content: "타이머 시작하기")
+                    .padding(.vertical, 20)
             })
-            .padding(.vertical, 20)
         }
     }
 }
+
 #Preview("TaskTimer") {
     TaskTimer()
 }

--- a/Boong-To-Do/View/Component/TaskTimer.swift
+++ b/Boong-To-Do/View/Component/TaskTimer.swift
@@ -1,0 +1,67 @@
+//
+//  TaskTimer.swift
+//  Boong-To-Do
+//
+//  Created by 황석현 on 6/14/24.
+//
+
+import SwiftUI
+
+/**할일을 진행할 때, 사용되는 타이머 컴포넌트*/
+struct TaskTimer: View {
+    
+    // TODO: 데이터 연동하기
+    @State var progress = 0.6
+    
+    var body: some View {
+        VStack {
+            ZStack {
+                Circle()
+                    .stroke(lineWidth: 15)
+                    .opacity(0.3)
+                    .frame(width: 250, height: 250)
+                    .foregroundColor(.gray)
+                
+                VStack {
+                    // TODO: 데이터 연동하기
+                    Text("20:00")
+                        .font(.system(size: 70))
+                        .foregroundStyle(.opacity(0.5))
+                    // TODO: 데이터 연동하기
+                    Text("20분")
+                        .font(.system(size: 16))
+                        .foregroundStyle(.opacity(0.5))
+                }
+                .padding(40)
+                
+                Circle()
+                    .trim(from: 0.0, to: CGFloat(min(progress, 1.0)))
+                    .stroke(style: StrokeStyle(lineWidth: 15, lineCap: .round, lineJoin: .round))
+                    .frame(width: 250, height: 250)
+                    .foregroundColor(Color(.black))
+                    .rotationEffect(Angle(degrees: 270.0))
+            }
+            
+            Button(action: {
+                // TODO: 타이머 시작하기
+            }, label: {
+                Text("타이머 시작하기")
+                    .foregroundStyle(.white)
+                    .bold()
+                    .frame(width: 140)
+                    .padding()
+                    .background(.black)
+                    .clipShape(.rect(cornerRadius: 100))
+            })
+            .padding(.top, 20)
+        }
+    }
+}
+#Preview("TaskTimer") {
+    TaskTimer()
+}
+
+#Preview("TaskProcessView") {
+    TaskProcessView()
+}
+

--- a/Boong-To-Do/View/Component/TaskTimer.swift
+++ b/Boong-To-Do/View/Component/TaskTimer.swift
@@ -12,6 +12,8 @@ struct TaskTimer: View {
     
     // TODO: 데이터 연동하기
     @State var progress = 0.6
+    @State var isStarted = false
+    @State var isRunning = false
     
     var body: some View {
         VStack {
@@ -42,12 +44,36 @@ struct TaskTimer: View {
                     .rotationEffect(Angle(degrees: 270.0))
             }
             // TODO: 타이머 시작하면, 버튼 2개 생성(재생/정지, 할일 완료)
-            Button(action: {
-                // TODO: 타이머 시작하기
-            }, label: {
-                TextButton(content: "타이머 시작하기")
-                    .padding(.vertical, 20)
-            })
+            if !isStarted {
+                Button(action: {
+                    isStarted.toggle()
+                }, label: {
+                    TextButton(content: "타이머 시작하기")
+                        .padding(.vertical, 20)
+                })
+            } else {
+                HStack {
+                    // TODO: if Timer.invalid() 추가
+                    if isRunning {
+                        Button(action: {
+                            // TODO: 타이머 재실행
+                            isRunning.toggle()
+                        }, label: {
+                            SystemImageButton(imageName: SystemImage.play.name, width: 12, height: 12)
+                        })
+                    } else {
+                        Button(action: {
+                            // TODO: 타이머 정지
+                            isRunning.toggle()
+                        }, label: {
+                            SystemImageButton(imageName: SystemImage.pause.name, width: 12, height: 12)
+                        })
+                    }
+                    
+                    TextButton(content: "할 일 완료")
+                }
+                .padding(.vertical, 20)
+            }
         }
     }
 }

--- a/Boong-To-Do/View/EmptyListView.swift
+++ b/Boong-To-Do/View/EmptyListView.swift
@@ -52,7 +52,7 @@ struct EmptyListView: View {
                         addTaskIsPresented.toggle()
                     }, label: {
                         ZStack {
-                            Image(systemName: "plus")   
+                            Image(systemName: SystemImage.plus.name)
                                 .resizable()
                                 .frame(width: 23, height: 23)
                                 .foregroundStyle(.white)

--- a/Boong-To-Do/View/HomeView.swift
+++ b/Boong-To-Do/View/HomeView.swift
@@ -39,10 +39,10 @@ struct HomeView: View {
                 .onAppear {
                     viewModel.getTaskStates()
                 }
-            if !viewModel.notCompleteTasks.isEmpty && !viewModel.completeTasks.isEmpty {
-                TaskListView(viewModel: viewModel)
-            } else {
+            if viewModel.notCompleteTasks.isEmpty && viewModel.completeTasks.isEmpty {
                 EmptyListView()
+            } else {
+                TaskListView(viewModel: viewModel)
             }
         }
     }

--- a/Boong-To-Do/View/HomeView.swift
+++ b/Boong-To-Do/View/HomeView.swift
@@ -24,7 +24,7 @@ struct HomeView: View {
                 Button(action: {
                     // TODO: 버튼을 누르면 어떤 기능?
                 }, label: {
-                    Image(systemName: "ellipsis")
+                    Image(systemName: SystemImage.ellipsis.name)
                         .resizable()
                         .scaledToFit()
                         .frame(width: 24, height: 24)

--- a/Boong-To-Do/View/TaskListView.swift
+++ b/Boong-To-Do/View/TaskListView.swift
@@ -25,9 +25,26 @@ struct TaskListView: View {
                         ForEach(viewModel.notCompleteTasks) { dummy in
                             TaskListCell(taskTitle: dummy.taskTitle, taskDuration: dummy.taskDuration, taskHasDone: dummy.taskHasDone)
                                 .sheet(isPresented: $isPresented, content: {
-                                    TaskProcessView()
-                                        .presentationDetents([.height(580)])
-                                        .presentationDragIndicator(.visible)
+                                    VStack {
+                                        HStack {
+                                            Spacer()
+                                            EllipsisMenu(isPresented: $isPresented)
+                                            .alert(isPresented: $isPresented) {
+                                                let deleteButton = Alert.Button.default(Text("취소")) {
+                                                    isPresented.toggle()
+                                                }
+                                                let cancelButton = Alert.Button.cancel(Text("삭제하기")) {
+                                                    // TODO: 데이터 삭제기능 추가
+                                                    print("데이터 삭제")
+                                                }
+                                                return Alert(title: Text("할 일 삭제"), message: Text("할일을 정말 삭제하시겠습니까?"), primaryButton: cancelButton, secondaryButton: deleteButton)
+                                            }
+                                        }
+                                        .padding(20)
+                                        TaskProcessView()
+                                            .presentationDetents([.height(580)])
+                                            .presentationDragIndicator(.visible)
+                                    }
                                 })
                         }
                         .onTapGesture { isPresented.toggle() }

--- a/Boong-To-Do/View/TaskListView.swift
+++ b/Boong-To-Do/View/TaskListView.swift
@@ -25,7 +25,7 @@ struct TaskListView: View {
                         ForEach(viewModel.notCompleteTasks) { dummy in
                             TaskListCell(taskTitle: dummy.taskTitle, taskDuration: dummy.taskDuration, taskHasDone: dummy.taskHasDone)
                                 .sheet(isPresented: $isPresented, content: {
-                                    TaskDetail()
+                                    TaskProcessView()
                                         .presentationDetents([.height(580)])
                                         .presentationDragIndicator(.visible)
                                 })
@@ -48,7 +48,7 @@ struct TaskListView: View {
                         ForEach(viewModel.completeTasks) { dummy in
                             TaskListCell(taskTitle: dummy.taskTitle, taskDuration: dummy.taskDuration, taskHasDone: dummy.taskHasDone)
                                 .sheet(isPresented: $isPresented, content: {
-                                    TaskDetail()
+                                    TaskProcessView()
                                         .presentationDetents([.height(580)])
                                         .presentationDragIndicator(.visible)
                                 })

--- a/Boong-To-Do/View/TaskListView.swift
+++ b/Boong-To-Do/View/TaskListView.swift
@@ -28,17 +28,7 @@ struct TaskListView: View {
                                     VStack {
                                         HStack {
                                             Spacer()
-                                            EllipsisMenu(isPresented: $isPresented)
-                                            .alert(isPresented: $isPresented) {
-                                                let deleteButton = Alert.Button.default(Text("취소")) {
-                                                    isPresented.toggle()
-                                                }
-                                                let cancelButton = Alert.Button.cancel(Text("삭제하기")) {
-                                                    // TODO: 데이터 삭제기능 추가
-                                                    print("데이터 삭제")
-                                                }
-                                                return Alert(title: Text("할 일 삭제"), message: Text("할일을 정말 삭제하시겠습니까?"), primaryButton: cancelButton, secondaryButton: deleteButton)
-                                            }
+                                            EllipsisMenu(isPresented: isPresented)
                                         }
                                         .padding(20)
                                         TaskProcessView()
@@ -61,27 +51,28 @@ struct TaskListView: View {
                         .padding()
                     }
                     // MARK: 완료 할일 리스트
-                    Section {
-                        ForEach(viewModel.completeTasks) { dummy in
-                            TaskListCell(taskTitle: dummy.taskTitle, taskDuration: dummy.taskDuration, taskHasDone: dummy.taskHasDone)
-                                .sheet(isPresented: $isPresented, content: {
-                                    TaskProcessView()
-                                        .presentationDetents([.height(580)])
-                                        .presentationDragIndicator(.visible)
-                                })
+                    if !viewModel.completeTasks.isEmpty {
+                        Section {
+                            ForEach(viewModel.completeTasks) { dummy in
+                                TaskListCell(taskTitle: dummy.taskTitle, taskDuration: dummy.taskDuration, taskHasDone: dummy.taskHasDone)
+                                    .sheet(isPresented: $isPresented, content: {
+                                        TaskProcessView()
+                                            .presentationDetents([.height(580)])
+                                            .presentationDragIndicator(.visible)
+                                    })
+                            }
+                            .onTapGesture {
+                                isPresented.toggle()
+                            }
+                        } header: {
+                            HStack {
+                                Text("완료")
+                                
+                                Spacer()
+                            }
+                            .padding()
                         }
-                        .onTapGesture {
-                            isPresented.toggle()
-                        }
-                    } header: {
-                        HStack {
-                            Text("완료")
-                            
-                            Spacer()
-                        }
-                        .padding()
                     }
-                    
                     
                     Spacer()
                 }

--- a/Boong-To-Do/View/TaskListView.swift
+++ b/Boong-To-Do/View/TaskListView.swift
@@ -140,6 +140,14 @@ struct TaskListCell: View {
         .padding(20)
         .background(taskHasDone ? .secondaryText.opacity(0.1) : .white)
         .clipShape(.rect(cornerRadius: 12))
+        .contextMenu {
+            Button(role: .destructive) {
+                // TODO: 선택 셀 데이터 삭제
+            } label: {
+                Label("삭제하기", systemImage: "trash")
+            }
+        }
+        .clipShape(.rect(cornerRadius: 12))
         .padding(.horizontal, 10)
     }
 }

--- a/Boong-To-Do/View/TaskListView.swift
+++ b/Boong-To-Do/View/TaskListView.swift
@@ -39,7 +39,7 @@ struct TaskListView: View {
                             
                             // TODO: 정렬 기능 구현하기
                             Text("정렬")
-                            Image(systemName: "arrow.up.arrow.down")
+                            Image(systemName: SystemImage.alignArrow.name)
                         }
                         .padding()
                     }
@@ -78,7 +78,7 @@ struct TaskListView: View {
                         addTaskIsPresented.toggle()
                     }, label: {
                         ZStack {
-                            Image(systemName: "plus")
+                            Image(systemName: SystemImage.plus.name)
                                 .resizable()
                                 .frame(width: 23, height: 23)
                                 .foregroundStyle(.white)
@@ -128,7 +128,7 @@ struct TaskListCell: View {
             Spacer()
             
             Button(action: {}, label: {
-                Label("\(taskDuration)분", systemImage: "clock")
+                Label("\(taskDuration)분", systemImage: SystemImage.clock.name)
                     .font(.system(size: 10))
                     .foregroundStyle(.black)
             })

--- a/Boong-To-Do/View/TaskProcessView.swift
+++ b/Boong-To-Do/View/TaskProcessView.swift
@@ -1,0 +1,29 @@
+//
+//  TaskProcessView.swift
+//  Boong-To-Do
+//
+//  Created by 황석현 on 6/25/24.
+//
+
+import SwiftUI
+
+/**할일 시작 시, 보여지는 타이머 화면(모달)
+ 
+ 할일 상세목록 + 타이머
+ */
+struct TaskProcessView: View {
+    var body: some View {
+        // TODO: 할일 상세사항을 보여주는 뷰를 만들어서 VStack으로 뷰1, 타이머 뷰로 감싼다.
+        VStack {
+            TaskDetail()
+            
+            TaskTimer()
+            
+        }
+        .padding(.horizontal, 20)
+    }
+}
+
+#Preview {
+    TaskProcessView()
+}

--- a/Boong-To-Do/ViewModel/TaskViewModel.swift
+++ b/Boong-To-Do/ViewModel/TaskViewModel.swift
@@ -15,7 +15,9 @@ class TaskViewModel: ObservableObject {
     
     func getTaskStates() {
         for item in MockTaskData.mockTaskArray {
-            if item.taskHasDone { completeTasks.append(item)} else {
+            if item.taskHasDone { 
+                completeTasks.append(item)
+            } else {
                 notCompleteTasks.append(item)
             }
         }


### PR DESCRIPTION
브랜치 이름과 상이한 PR 내용이라 죄송합니다 ㅠ_ㅜ

-----

# 작업 내용
1. 생성된 할일을 터치하면 삭제하는 팝업이 뜨는 화면을 만들었습니다.
2. 반복적으로 사용되는 화면을 SystemComponents.swift 파일에 모아봤습니다.
3. 색상, Enum을 추가하여 코드 가독성을 높여 보았습니다.
4. 메모 작성화면을 만들었습니다.

# 1
<div>
<img width="200" src="https://github.com/Code-Ward/Todo-Tycoon/assets/109560875/d8752c07-d4dc-48dc-b9d3-306957c9a590">
<img width="150" src="https://github.com/Code-Ward/Todo-Tycoon/assets/109560875/31f7054b-aab8-48d3-ab09-8f5384fd95cc">
<img width="150" src="https://github.com/Code-Ward/Todo-Tycoon/assets/109560875/70e98fa1-0f2b-4bff-9f0f-c8a7db289cd5">
<img width="150" src="https://github.com/Code-Ward/Todo-Tycoon/assets/109560875/90b8ecb6-e6fa-43a2-b034-e463819d50b3">
</div>

`.contextMenu`와 `Menu`, `.alert`를 사용하여 뷰를 만들어보았습니다.

# 2
<div>
<img width="1000" src="https://github.com/Code-Ward/Todo-Tycoon/assets/109560875/a4c72c2f-c3f4-439f-a4be-aafa686c6e3c">
<img height="200" src="https://github.com/Code-Ward/Todo-Tycoon/assets/109560875/43ae07d0-ab02-4df8-9cf8-ae2b79f2a855">
<img height="200" src="https://github.com/Code-Ward/Todo-Tycoon/assets/109560875/a4068f3c-a1e7-43f3-9918-1a29f2b4847c">
<img height="200" src="https://github.com/Code-Ward/Todo-Tycoon/assets/109560875/2f9047e6-f8a5-4634-9a24-c3ed0f3c4c23">
</div>

# 3
<img width="300" src="https://github.com/Code-Ward/Todo-Tycoon/assets/109560875/11b66bf3-ff03-4263-9001-b31819e8d011">

TextBoxColor를 추가하였고 이는 `Color.textBox`로 사용할 수 있습니다.


<img height="300" src="https://github.com/Code-Ward/Todo-Tycoon/assets/109560875/60018f6e-d45b-41fb-bd74-46ec866e0ae9">

`SystemImage`를 사용할 때, 오타 방지를 위해서 `Enum`&`Switch`로 작성해보았습니다.

# 4
<img width="300" src="https://github.com/Code-Ward/Todo-Tycoon/assets/109560875/34486fbf-6c19-43b0-88f2-29d3f41acc6c">

할일 완료 시, 메모를 작성화면을 만들었습니다.
아직 기능적으로 연결은 되어있지 않습니다.

