### PR TITLE
#16 - 일부 기능 수정 및 개선

### DIFF
--- a/Todo-Tycoon/View/Component/DurationSelector.swift
+++ b/Todo-Tycoon/View/Component/DurationSelector.swift
@@ -82,7 +82,7 @@ struct DurationSelector: View {
                 isPresented.toggle()
                 todoRequiredTime = viewModel.getRequiredTime(hours: hourSelection, minutes: minuteSelection)
             }, label: {
-                Text("추가하러 가기")
+                Text("적용하기")
                     .foregroundColor(.white)
                     .font(.system(size: 16))
                     .bold()

--- a/Todo-Tycoon/View/Component/DurationSelector.swift
+++ b/Todo-Tycoon/View/Component/DurationSelector.swift
@@ -22,19 +22,7 @@ struct DurationSelector: View {
         VStack {
             // X를 누르면 모달 Dismiss
             // 데이터를 저장
-            Button(action: {
-                isPresented.toggle()
-                todoRequiredTime = viewModel.getRequiredTime(hours: hourSelection, minutes: minuteSelection)
-            }, label: {
-                HStack {
-                    Spacer()
-                    
-                    Image(systemName: SystemImage.xMark.name)
-                        .padding(.horizontal)
-                        .foregroundStyle(.black)
-                        .bold()
-                }
-            })
+            
             
             HStack {
                 Text("예상 소요 시간")
@@ -87,7 +75,24 @@ struct DurationSelector: View {
                 
                 Text("분")
             }
+            
             .padding()
+            
+            Button(action: {
+                isPresented.toggle()
+                todoRequiredTime = viewModel.getRequiredTime(hours: hourSelection, minutes: minuteSelection)
+            }, label: {
+                Text("추가하러 가기")
+                    .foregroundColor(.white)
+                    .font(.system(size: 16))
+                    .bold()
+                    .frame(height: 56)
+                    .frame(maxWidth: .infinity)
+                    .background(.black)
+                    .clipShape(.rect(cornerRadius: 8))
+                    .padding(.horizontal, 20)
+                    .padding(.vertical, 12)
+            })
         }
     }
 }

--- a/Todo-Tycoon/View/Component/EllipsisMenu.swift
+++ b/Todo-Tycoon/View/Component/EllipsisMenu.swift
@@ -10,38 +10,15 @@ import SwiftUI
 /**메뉴: 입력 기능 작동*/
 struct EllipsisMenu: View {
     
-    @State var isPresented = false
-    var action: () -> Void
-    
     var body: some View {
-        Menu {
-            
-            Button(role: .destructive, action: {
-                isPresented.toggle()
-            }, label: {
-                Label("삭제하기", systemImage: SystemImage.trash.name)
-            })
-            
-        } label: {
-            Image(systemName: SystemImage.ellipsis.name)
-                .resizable()
-                .scaledToFit()
-                .frame(width: 24, height: 24)
-                .foregroundStyle(.black)
-        }
-        .alert(isPresented: $isPresented) {
-            let deleteButton = Alert.Button.default(Text("취소")) {
-                isPresented.toggle()
-            }
-            let cancelButton = Alert.Button.cancel(Text("삭제하기")) {
-                action()
-                isPresented.toggle()
-            }
-            return Alert(title: Text("할 일 삭제"), message: Text("할일을 정말 삭제하시겠습니까?"), primaryButton: cancelButton, secondaryButton: deleteButton)
-        }
+        Image(systemName: SystemImage.ellipsis.name)
+            .resizable()
+            .scaledToFit()
+            .frame(width: 24, height: 24)
+            .foregroundStyle(.black)
     }
 }
 
 #Preview("EllipsisMenu") {
-    EllipsisMenu(action: { print("EllipsisMenu Preview!")})
+    EllipsisMenu()
 }

--- a/Todo-Tycoon/View/Component/TodoInfo.swift
+++ b/Todo-Tycoon/View/Component/TodoInfo.swift
@@ -12,8 +12,6 @@ struct TodoInfo: View {
     
     @EnvironmentObject var viewModel: TodoViewModel
     @State var todo: Todo
-    @State var isTitleEditing = false
-    @State var isContentEditing = false
     @State var isRequiredTimeEditing = false
     @State var durationSelectorPresented = false
     @State var titleEdit = ""
@@ -22,7 +20,7 @@ struct TodoInfo: View {
     
     var body: some View {
         VStack {
-            // 제목
+            // MARK: 제목
             HStack {
                 if viewModel.isEditing {
                     TextField(todo.title, text: $titleEdit)
@@ -36,9 +34,6 @@ struct TodoInfo: View {
                     Text("\(todo.title)")
                         .font(.system(size: 16))
                         .bold()
-                        .onTapGesture {
-                            isTitleEditing.toggle()
-                        }
                     Spacer()
                 }
                     
@@ -47,17 +42,15 @@ struct TodoInfo: View {
             .frame(height: 24)
             .onChange(of: viewModel.isEditing) {
                 if titleEdit.isEmpty {
-                    isTitleEditing.toggle()
                     print("No Changes")
                 } else {
-                    isTitleEditing.toggle()
                     viewModel.changeTodoTitle(todo: todo, title: titleEdit)
                     viewModel.fetchTodo()
                     print("Edit Complete")
                 }
             }
             
-            // 설명
+            // MARK: 설명
             HStack {
                 if viewModel.isEditing {
                     TextField(todo.content, text: $contentEdit)
@@ -74,17 +67,11 @@ struct TodoInfo: View {
                             .font(.system(size: 12))
                             .frame(minHeight: 50, alignment: .top)
                             .lineLimit(8)
-                            .onTapGesture {
-                                isContentEditing.toggle()
-                            }
                     } else {
                         Text("\(todo.content)")
                             .font(.system(size: 12))
                             .frame(minHeight: 50, alignment: .top)
                             .lineLimit(8)
-                            .onTapGesture {
-                                isContentEditing.toggle()
-                            }
                     }
                     
                     Spacer()
@@ -97,16 +84,14 @@ struct TodoInfo: View {
             })
             .onChange(of: viewModel.isEditing) {
                 if contentEdit.isEmpty {
-                    isContentEditing.toggle()
                     print("No Changes")
                 } else {
-                    isContentEditing.toggle()
                     viewModel.changeTodoContent(todo: todo, content: contentEdit)
                     print("Edit Complete")
                 }
             }
             
-            // 예상소요시간
+            // MARK: 예상소요시간
             HStack {
                 Label(
                     title: {

--- a/Todo-Tycoon/View/Component/TodoInfo.swift
+++ b/Todo-Tycoon/View/Component/TodoInfo.swift
@@ -24,24 +24,14 @@ struct TodoInfo: View {
         VStack {
             // 제목
             HStack {
-                if isTitleEditing {
+                if viewModel.isEditing {
                     TextField(todo.title, text: $titleEdit)
                         .font(.system(size: 16))
                         .bold()
                         .onChange(of: titleEdit) {
                             todo.title = titleEdit
                         }
-                    Button(action: {
-                        if titleEdit.isEmpty {
-                            isTitleEditing.toggle()
-                        } else {
-                            isTitleEditing.toggle()
-                            viewModel.changeTodoTitle(todo: todo, title: titleEdit)
-                            viewModel.fetchTodo()
-                        }
-                    }, label: {
-                        Text("완료")
-                    })
+                        
                 } else {
                     Text("\(todo.title)")
                         .font(.system(size: 16))
@@ -51,13 +41,25 @@ struct TodoInfo: View {
                         }
                     Spacer()
                 }
+                    
             }
             .frame(maxWidth: .infinity)
             .frame(height: 24)
+            .onChange(of: viewModel.isEditing) {
+                if titleEdit.isEmpty {
+                    isTitleEditing.toggle()
+                    print("No Changes")
+                } else {
+                    isTitleEditing.toggle()
+                    viewModel.changeTodoTitle(todo: todo, title: titleEdit)
+                    viewModel.fetchTodo()
+                    print("Edit Complete")
+                }
+            }
             
             // 설명
             HStack {
-                if isContentEditing {
+                if viewModel.isEditing {
                     TextField(todo.content, text: $contentEdit)
                         .font(.system(size: 12))
                         .bold()
@@ -65,16 +67,7 @@ struct TodoInfo: View {
                         .onChange(of: contentEdit) {
                             todo.content = contentEdit
                         }
-                    Button(action: {
-                        if contentEdit.isEmpty {
-                            isContentEditing.toggle()
-                        } else {
-                            isContentEditing.toggle()
-                            viewModel.changeTodoContent(todo: todo, content: contentEdit)
-                        }
-                    }, label: {
-                        Text("완료")
-                    })
+                        
                 } else {
                     if todo.content.isEmpty {
                         Text("설명 없음")
@@ -102,6 +95,16 @@ struct TodoInfo: View {
                     .presentationDetents([.height(368)])
                     .presentationDragIndicator(.visible)
             })
+            .onChange(of: viewModel.isEditing) {
+                if contentEdit.isEmpty {
+                    isContentEditing.toggle()
+                    print("No Changes")
+                } else {
+                    isContentEditing.toggle()
+                    viewModel.changeTodoContent(todo: todo, content: contentEdit)
+                    print("Edit Complete")
+                }
+            }
             
             // 예상소요시간
             HStack {
@@ -138,6 +141,12 @@ struct TodoInfo: View {
                         viewModel.fetchTodo()
                     }, label: {
                         Text("완료")
+                            .foregroundColor(.white)
+                            .font(.system(size: 16))
+                            .bold()
+                            .frame(width: 50, height: 30)
+                            .background(.black)
+                            .clipShape(.rect(cornerRadius: 8))
                     })
                 }
                 
@@ -148,6 +157,7 @@ struct TodoInfo: View {
 
 #Preview("TodoDetail") {
     TodoInfo(todo: Todo(title: "TodoDetail", requiredTime: 1, createdAt: Date.now))
+        .environmentObject(TodoViewModel())
 }
 
 

--- a/Todo-Tycoon/View/HomeView.swift
+++ b/Todo-Tycoon/View/HomeView.swift
@@ -52,4 +52,5 @@ struct HomeView: View {
 
 #Preview() {
     HomeView()
+        .environmentObject(TodoViewModel())
 }

--- a/Todo-Tycoon/View/TodoDetailView.swift
+++ b/Todo-Tycoon/View/TodoDetailView.swift
@@ -15,13 +15,67 @@ struct TodoDetailView: View {
     
     @EnvironmentObject var viewModel: TodoViewModel
     @State var todo: Todo
+    @State var alertPresented: Bool = false
     @Binding var isPresented: Bool
     
     var body: some View {
         VStack {
             HStack {
                 Spacer()
-                EllipsisMenu(action: { viewModel.deleteTodo(id: todo.id) })
+                if !viewModel.isEditing {
+                    Menu {
+                        // 삭제하기
+                        Button(role: .destructive) {
+                            print("삭제하기")
+                            alertPresented.toggle()
+                        } label: {
+                            Label("삭제하기", systemImage: SystemImage.trash.name)
+                        }
+                        // 수정하기
+                        Button() {
+                            // Action -
+                            print("수정하기")
+                            viewModel.isEditing.toggle()
+                        } label: {
+                            Label("수정하기", systemImage: "pencil.tip.crop.circle")
+                        }
+                    } label: {
+                        Image(systemName: SystemImage.ellipsis.name)
+                            .resizable()
+                            .scaledToFit()
+                            .frame(width: 24, height: 24)
+                            .foregroundStyle(.black)
+                    }
+                    .alert(isPresented: $alertPresented) {
+                        let deleteButton = Alert.Button.default(Text("삭제하기")) {
+                            // 삭제하기 동작 코드
+                            print("삭제하기 동작")
+                            alertPresented.toggle()
+                            viewModel.deleteTodo(id: todo.id)
+                        }
+                        let cancelButton = Alert.Button.cancel(Text("취소")) {
+                            // 취소 동작 코드
+                            print("취소 동작")
+                            alertPresented.toggle()
+                        }
+                        return Alert(title: Text("할 일 삭제"), message: Text("할일을 정말 삭제하시겠습니까?"), primaryButton: cancelButton, secondaryButton: deleteButton)
+                    }
+                } else {
+                    Button {
+                        viewModel.isEditing.toggle()
+                        
+                    } label: {
+                        Text("완료")
+                            .foregroundColor(.white)
+                            .font(.system(size: 16))
+                            .bold()
+                            .frame(width: 50, height: 30)
+                            .background(.black)
+                            .clipShape(.rect(cornerRadius: 8))
+                            .padding()
+                    }
+
+                }
             }
             
             TodoInfo(todo: todo)

--- a/Todo-Tycoon/View/TodoListView.swift
+++ b/Todo-Tycoon/View/TodoListView.swift
@@ -101,8 +101,10 @@ struct TodoListView: View {
                                             HStack {
                                                 Spacer()
                                                 
-                                                EllipsisMenu {
+                                                Button {
                                                     // TODO: 기능 추가 예정(미정)
+                                                } label: {
+                                                    EllipsisMenu()
                                                 }
                                             }
                                             

--- a/Todo-Tycoon/ViewModel/TodoViewModel.swift
+++ b/Todo-Tycoon/ViewModel/TodoViewModel.swift
@@ -13,6 +13,7 @@ class TodoViewModel: ObservableObject {
 
     var today = Date()
     var timer: Timer?
+    @Published var isEditing = false
     @Published var completeTodos: [Todo] = []
     @Published var notCompleteTodos: [Todo] = []
     @Published var processingTodos: [Todo] = []


### PR DESCRIPTION
#16 내용을 기준으로 작업하였습니다.

-------

# 1. 예상 소요시간 화면 일부 수정
- 우측 상단의 `[X]` 를 `[적용하기]` 버튼으로 수정하고 하단에 위치하게 변경했습니다.
<div>
<img width="200" src="https://github.com/user-attachments/assets/40272c4d-4d13-49ab-b0f8-8aa12cae8ae7">
</div>

# 2. 할일 상세보기의 수정모드
- [수정할 컨텐츠를 터치]하는 방식에서 `[```]`를 눌러서 수정하기를 선택하는 방식으로 수정
- 수정모드 후의 화면은 임의로 개발함
<div>
<img width="200" src="https://github.com/user-attachments/assets/b5de1b6c-2991-4fa3-9764-05aef42f707e">
</div>

## 추가
### EditMode
`ViewModel`에 `@Published isEditing` 변수를 추가하였습니다.
해당 변수를 통해 `EditMode`처럼 데이터를 관리할 수 있게 코드를 작성 해보았습니다.

`EditMode` 구조체를 사용하지 않고 변수를 추가한 이유는
해당 `EditMode`에 수정하는 기능을 구현되어 있지 않아 
어차피 해당 기능을 추가해야하고, 현재 구조에서는 알맞지 않다고 생각하여
사용하지 않았습니다.

### ElipsisMenu
원하는 기능이나 함수를 매개변수로 받아서 재사용하기 용이하게 만들어서 활용할 생각으로 
해당 뷰를 정의했었는데, `ElipsisMenu`는 상황에 따라서 메뉴의 종류와 기능이 달라지기에
오히려 재사용하기 어렵다고 판단하여
단순 `View`로 코드를 수정하여 단순 사용하기에 적합하게 만들었습니다.
